### PR TITLE
Add crawler and form finder

### DIFF
--- a/core/interactive.py
+++ b/core/interactive.py
@@ -1,4 +1,5 @@
 import cmd
+from utils.crawler import crawl, findPageForms
 from utils.loggers import log
 from urllib import parse
 from core import checks
@@ -47,6 +48,9 @@ Information:
 
 Target:
   url, target [URL]                       Set target URL (e.g. 'https://example.com/?name=test')
+  crawl [DEPTH]                           Crawl up to depth
+  exclude [PATTERN]                       Regex pattern to exclude from crawler
+  forms                                   Search page(s) for forms
   run, test, check                        Run SSTI detection on the target
 
 Request:
@@ -146,14 +150,59 @@ Exploitation:
 
     do_target = do_url
 
+    def do_crawl(self, line):
+        if not self.sstimap_options["url"]:
+            log.log(22, 'Target URL cannot be empty.')
+            return
+        self.sstimap_options['crawlDepth'] = int(line)
+        
+    def do_exclude(self, line):
+        self.sstimap_options['crawlDepth'] = line
+    
+    do_crawl_exclude = do_exclude
+    do_crawlexclude = do_exclude
+        
+    def do_forms(self, line):
+        if self.sstimap_options['forms'] == False:
+            self.sstimap_options['forms'] = True
+            log.log(24, f'SSTImap will scan for forms')
+        elif self.sstimap_options['forms'] == True:
+            self.sstimap_options['forms'] = False
+            log.log(26, f'Disabling form scan')
+
     def do_run(self, line):
         """Check target URL for SSTI vulnerabilities"""
         if not self.sstimap_options["url"]:
             log.log(22, 'Target URL cannot be empty.')
             return
         try:
-            self.channel = Channel(self.sstimap_options)
-            self.current_plugin = checks.check_template_injection(self.channel)
+            if self.sstimap_options['crawlDepth'] or self.sstimap_options['forms']:
+                # crawler mode
+                urls = set([self.sstimap_options['url']])
+                if self.sstimap_options['crawlDepth']:
+                    crawled_urls = set()
+                    for url in urls:
+                        crawled_urls.update(crawl(url, self.sstimap_options))
+                    urls.update(crawled_urls)
+                if not self.sstimap_options['forms']:
+                    for url in urls:
+                        self.sstimap_options['url'] = url
+                        self.channel = Channel(self.sstimap_options)
+                        self.current_plugin = checks.check_template_injection(self.channel)
+                else:
+                    forms = set()
+                    for url in urls:
+                        forms.update(findPageForms(url, self.sstimap_options))
+                    for form in forms:
+                        self.sstimap_options['url'] = form[0]
+                        self.sstimap_options['method'] = form[1]
+                        self.sstimap_options['data'] = parse.parse_qs(form[2], keep_blank_values=True)
+                        self.channel = Channel(self.sstimap_options)
+                        self.current_plugin = checks.check_template_injection(self.channel)
+            else:
+                # predetermined mode
+                self.channel = Channel(self.sstimap_options)
+                self.current_plugin = checks.check_template_injection(self.channel)
         except (KeyboardInterrupt, EOFError):
             log.log(26, 'Exiting SSTI detection')
         self.checked = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 argparse~=1.4.0
 requests~=2.27.1
 urllib3~=1.26.9
+mechanize~=0.4.8
+html5lib~=1.1

--- a/sstimap.py
+++ b/sstimap.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 import sys
+import urllib
+
 from utils import cliparser
 from core import checks
 from core.channel import Channel
 from core.interactive import InteractiveShell
 from utils.loggers import log
+from utils.crawler import crawl, findPageForms
 import traceback
+
 
 version = '1.0.2'
 
@@ -20,6 +24,27 @@ def main():
         # interactive mode
         log.log(23, 'Starting SSTImap in interactive mode. Type \'help\' to see the details.')
         InteractiveShell(args).cmdloop()
+    elif args['crawlDepth'] or args['forms']:
+        # crawler mode
+        urls = set([args.get('url')])
+        if args['crawlDepth']:
+            crawled_urls = set()
+            for url in urls:
+                crawled_urls.update(crawl(url, args))
+            urls.update(crawled_urls)
+        if not args['forms']:
+            for url in urls:
+                args['url'] = url
+                checks.check_template_injection(Channel(args))
+        else:
+            forms = set()
+            for url in urls:
+                forms.update(findPageForms(url, args))
+            for form in forms:
+                args['url'] = form[0]
+                args['method'] = form[1]
+                args['data'] = urllib.parse.parse_qs(form[2], keep_blank_values=True)
+                checks.check_template_injection(Channel(args))
     else:
         # predetermined mode
         checks.check_template_injection(Channel(args))

--- a/utils/cliparser.py
+++ b/utils/cliparser.py
@@ -33,6 +33,12 @@ target.add_argument("-u", "--url", dest="url",
                     help="Target URL (e.g. 'https://example.com/?name=test')")
 target.add_argument("-i", "--interactive", action="store_true", dest="interactive",
                     help="Run SSTImap in interactive mode")
+target.add_argument("--crawl", dest="crawlDepth", type=int,
+                    help="Depth to crawl (default: don't crawl)", default=0)
+target.add_argument("--crawl-exclude", dest="crawlExclude",
+                    help="Regex in URLs to not crawl")
+target.add_argument("--forms", action="store_true", dest="forms",
+                    help="Scan page(s) for forms")
 
 
 request = parser.add_argument_group(title="request", description="These options can specify how to connect to the "
@@ -46,7 +52,7 @@ request.add_argument("-H", "--header", action="append", dest="headers", metavar=
 request.add_argument("-c", "--cookie", action="append", dest="cookies", metavar="COOKIE",
                      help="Cookie to send (e.g. 'Field=Value') [Stackable]", default=[])
 request.add_argument("-m", "--method", dest="method",
-                     help="HTTP method to use (default 'GET')", default='GET')
+                     help="HTTP method to use (default 'GET')")
 request.add_argument("-a", "--user-agent", dest="user_agent",
                      help="User-Agent header value to use", default=f'SSTImap/{version}')
 request.add_argument("-A", "--random-user-agent", action="store_true", dest="random_agent",

--- a/utils/crawler.py
+++ b/utils/crawler.py
@@ -1,0 +1,200 @@
+ #!/usr/bin/env python
+
+"""
+Copyright (c) 2006-2022 sqlmap developers (https://sqlmap.org/)
+See the file 'LICENSE' for copying permission
+"""
+
+import re
+import urllib
+import http
+import html
+import requests
+
+#from bs4 import BeautifulSoup
+from mechanize._form import parse_forms
+from html5lib import parse
+
+from utils import cliparser
+from utils.loggers import log
+
+
+def crawl(target, args):
+    CRAWL_EXCLUDE_EXTENSIONS = ("3ds", "3g2", "3gp", "7z", "DS_Store", "a", "aac", "adp", "ai", "aif", "aiff", "apk", "ar", "asf", "au", "avi", "bak", "bin", "bk", "bmp", "btif", "bz2", "cab", "caf", "cgm", "cmx", "cpio", "cr2", "dat", "deb", "djvu", "dll", "dmg", "dmp", "dng", "doc", "docx", "dot", "dotx", "dra", "dsk", "dts", "dtshd", "dvb", "dwg", "dxf", "ear", "ecelp4800", "ecelp7470", "ecelp9600", "egg", "eol", "eot", "epub", "exe", "f4v", "fbs", "fh", "fla", "flac", "fli", "flv", "fpx", "fst", "fvt", "g3", "gif", "gz", "h261", "h263", "h264", "ico", "ief", "image", "img", "ipa", "iso", "jar", "jpeg", "jpg", "jpgv", "jpm", "jxr", "ktx", "lvp", "lz", "lzma", "lzo", "m3u", "m4a", "m4v", "mar", "mdi", "mid", "mj2", "mka", "mkv", "mmr", "mng", "mov", "movie", "mp3", "mp4", "mp4a", "mpeg", "mpg", "mpga", "mxu", "nef", "npx", "o", "oga", "ogg", "ogv", "otf", "pbm", "pcx", "pdf", "pea", "pgm", "pic", "png", "pnm", "ppm", "pps", "ppt", "pptx", "ps", "psd", "pya", "pyc", "pyo", "pyv", "qt", "rar", "ras", "raw", "rgb", "rip", "rlc", "rz", "s3m", "s7z", "scm", "scpt", "sgi", "shar", "sil", "smv", "so", "sub", "swf", "tar", "tbz2", "tga", "tgz", "tif", "tiff", "tlz", "ts", "ttf", "uvh", "uvi", "uvm", "uvp", "uvs", "uvu", "viv", "vob", "war", "wav", "wax", "wbmp", "wdp", "weba", "webm", "webp", "whl", "wm", "wma", "wmv", "wmx", "woff", "woff2", "wvx", "xbm", "xif", "xls", "xlsx", "xlt", "xm", "xpi", "xpm", "xwd", "xz", "z", "zip", "zipx")
+    def crawlThread(curr_depth, current):
+        if current in visited:
+            return
+        elif args.get('crawlExclude') and re.search(args.get('crawlExclude'), current):
+            dbgMsg = "skipping '%s'" % current
+            log.log(26, dbgMsg)
+            return
+        else:
+            visited.add(current)
+        
+        content = None
+        try:
+            if current:
+                content = requests.request(method='GET', url=current, proxies={'http': args.get('proxy'), 'https': args.get('proxy')}, verify=args.get('verify_ssl')).text
+        except http.client.InvalidURL as ex:
+            errMsg = "invalid URL detected ('%s'). skipping " % ex
+            errMsg += "URL '%s'" % current
+            log.log(23, errMsg)
+        except urllib.error.HTTPError:  # unavailable page
+            pass
+        except urllib.error.URLError:
+            pass
+        except TimeoutError:
+            pass
+            
+        
+        if content:
+            try:
+                match = re.search(r"(?si)<html[^>]*>(.+)</html>", content)
+                if match:
+                    content = "<html>%s</html>" % match.group(1)
+        
+                #soup = BeautifulSoup(content)
+                #tags = soup('a')
+                tags = []
+        
+                tags += re.finditer(r'(?i)\s(href|src)=["\'](?P<href>[^>"\']+)', content)
+                tags += re.finditer(r'(?i)window\.open\(["\'](?P<href>[^)"\']+)["\']', content)
+                
+                for tag in tags:
+                    href = tag.get("href") if hasattr(tag, "get") else tag.group("href")
+                    if href:
+                        url = urllib.parse.urljoin(current, html.unescape(href))
+                        try:
+                            if re.search(r"\A[^?]+\.(?P<result>\w+)(\?|\Z)", url).group("result").lower() in CRAWL_EXCLUDE_EXTENSIONS:
+                                continue
+                        except AttributeError:      # for extensionless urls
+                            pass 
+                        if url:
+                            worker[curr_depth+1].add(url)
+            except UnicodeEncodeError:  # for non-HTML files
+                pass
+            except ValueError:          # for non-valid links
+                pass
+            except AssertionError:      # for invalid HTML
+                pass
+    """"""
+    if not target:
+        return set()
+
+    visited = set()
+    worker = [set([target])]
+    results = set()
+
+    try:
+        for depth in range(args.get('crawlDepth')): 
+            results.update(worker[depth])
+            worker.append(set())
+            for url in worker[depth]:
+                crawlThread(depth, url)
+        results.update(worker[args.get('crawlDepth')])
+                
+
+        if not results:
+            warnMsg = "no usable links found (with GET parameters)"
+            log.log(23, warnMsg)
+
+            
+        return results
+                
+        
+    except KeyboardInterrupt:
+        warnMsg = "user aborted during crawling. "
+        warnMsg += "SSTImap will use partial list"
+        log.log(26, warnMsg)
+
+
+
+def findPageForms(url, args):
+    try:
+        request = requests.request(method='GET', url=url, proxies={'http': args.get('proxy'), 'https': args.get('proxy')}, verify=args.get('verify_ssl'))
+        raw = request.content
+        content = request.text
+    except UnicodeDecodeError:
+        return set()
+    except http.client.InvalidURL as ex:
+        errMsg = "invalid URL detected ('%s'). skipping " % ex
+        errMsg += "URL '%s'" % url
+        log.log(23, errMsg)
+        return set()
+    except urllib.error.HTTPError:  # unavailable page
+        return set()
+    except urllib.error.URLError:
+        return set()
+    except http.client.InvalidURL:
+        return set()
+    except TimeoutError:
+        return set()
+    
+    forms = None
+    try:
+        parsed = parse(raw, **{'namespaceHTMLElements': False})
+        forms, global_form = parse_forms(parsed, request.url)
+    except ParseError:
+        if re.search(r"(?i)<!DOCTYPE html|<html", raw or "") and not re.search(r"(?i)\.js(\?|\Z)", url):
+            dbgMsg = "badly formed HTML at the given URL ('%s'). Going to filter it" % url
+            log.log(26, dbgMsg)
+            try:
+                parsed = parse("".join(re.findall(r"(?si)<form(?!.+<form).+?</form>", raw)), **{'namespaceHTMLElements': False})
+                forms, global_form = parse_forms(parsed, request.url)
+            except:
+                errMsg = "no success"
+                log.log(26, errMsg)
+                
+
+    retVal = set()
+    for form in forms or []:
+        try:
+            request = form.click()
+            if request.type == 'http' or request.type == 'https':
+                url = urllib.parse.unquote_plus(request.get_full_url())
+                method = request.get_method()
+                data = request.data
+                
+                if data:
+                    data = urllib.parse.unquote(request.data)
+                    data = data.lstrip("&=").rstrip('&')
+                elif not data and method and method.upper() == "POST":
+                    debugMsg = "invalid POST form with blank data detected"
+                    log.log(26, debugMsg)
+                    continue
+                    
+                target = (url, method, data)
+                retVal.add(target)
+        except (ValueError, TypeError) as ex:
+            errMsg = "there has been a problem while "
+            errMsg += "processing page forms ('%s')" % ex
+            log.log(26, errMsg)
+
+
+    try:
+        for match in re.finditer(r"\.post\(['\"]([^'\"]*)['\"],\s*\{([^}]*)\}", content):
+            url = urllib.parse.urljoin(url, html.unescape(match.group(1)))
+            data = ""
+    
+            for name, value in re.findall(r"['\"]?(\w+)['\"]?\s*:\s*(['\"][^'\"]+)?", match.group(2)):
+                data += "%s=%s%s" % (name, value, '&')
+    
+            data = data.rstrip('&')
+            
+            target = (url, "POST", data)
+            retVal.add(target)
+        for match in re.finditer(r"(?s)(\w+)\.open\(['\"]POST['\"],\s*['\"]([^'\"]+)['\"]\).*?\1\.send\(([^)]+)\)", content):
+            url = urllib.parse.urljoin(url, html.unescape(match.group(2)))
+            data = match.group(3)
+
+            data = re.sub(r"\s*\+\s*[^\s'\"]+|[^\s'\"]+\s*\+\s*", "", data)
+            data = data.strip("['\"]")
+            
+            target = (url, "POST", data)
+            retVal.add(target)
+    except UnicodeDecodeError:
+        pass
+
+    return retVal
+
+


### PR DESCRIPTION
Sorry for taking so long with this, the dependency hell was real with this one, and I have started a new job in the last couple of months, so I have been busy with that.

So you are aware I added a small fix, you had added a default value of GET to the method argument in the cliparser, but it was breaking method detection so I removed it. The code that I added to the main function is kind of messy and I would like to clean it up, but that will likely reorganizing the Channel class so it can be done later.

For new dependencies,  sqlmap's crawler had the option of using beautifulsoup, but the hardcoded fallbacks seem to work fine without it so I have disabled (commented out) the use of beautifulsoup. However in the form finder sqlmap used a library called clientform, and like all of sqlmaps dependencies is built-in, because clientform has never and will never be ported to python 3 (the developers consider the project obsolete). The developers of clientform recommend using their new library mechanize, however using mechanize the intended way is not an option for us; So I went with calling it's internal functions, however as an argument the functions take a large nested dataclass created by a different library called html5lib, so I had to add and call that too (html5lib is already a dependency of mechanize).

Also sqlmap is heavily threaded but SSTImap is not, so I have removed the use of threading but left the structure, so it can be added at a later date if somebody wants to.
